### PR TITLE
fix: busy/not-answered calls stay in agent worklist after call closure

### DIFF
--- a/src/main/java/com/iemr/ecd/service/associate/CallClosureImpl.java
+++ b/src/main/java/com/iemr/ecd/service/associate/CallClosureImpl.java
@@ -168,9 +168,12 @@ public class CallClosureImpl {
 				} else {
 					if (obj.getIsCallDisconnected() != null && obj.getIsCallDisconnected()) {
 						callObj.setCallStatus(Constants.OPEN);
-						callObj.setAllocatedUserId(null);  
-						callObj.setAllocationStatus(Constants.UNALLOCATED);  
-						callObj.setCallAttemptNo(0);  
+						if (request.getReasonForCallNotAnswered() == null ||
+								!Constants.REASONFORCALLNOTANSWERED.contains(request.getReasonForCallNotAnswered())) {
+							callObj.setAllocatedUserId(null);
+							callObj.setAllocationStatus(Constants.UNALLOCATED);
+							callObj.setCallAttemptNo(0);
+						}
 					} else {
 						callObj.setCallStatus(Constants.COMPLETED);
 						createEcdCallRecordsInOutboundCalls(request, callConfigurationDetails,
@@ -208,8 +211,6 @@ public class CallClosureImpl {
 				}
 				if(null != request.getReasonForCallNotAnswered() && Constants.REASONFORCALLNOTANSWERED.contains(request.getReasonForCallNotAnswered()) && !isMaxcallsAttempted) {
 					callObj.setCallStatus(Constants.OPEN);
-					callObj.setAllocatedUserId(request.getUserId());
-					callObj.setAllocationStatus(Constants.ALLOCATED);
 				}
 				
 				if (request.getIsHrp() != null) {

--- a/src/main/java/com/iemr/ecd/service/associate/CallClosureImpl.java
+++ b/src/main/java/com/iemr/ecd/service/associate/CallClosureImpl.java
@@ -208,6 +208,8 @@ public class CallClosureImpl {
 				}
 				if(null != request.getReasonForCallNotAnswered() && Constants.REASONFORCALLNOTANSWERED.contains(request.getReasonForCallNotAnswered()) && !isMaxcallsAttempted) {
 					callObj.setCallStatus(Constants.OPEN);
+					callObj.setAllocatedUserId(request.getUserId());
+					callObj.setAllocationStatus(Constants.ALLOCATED);
 				}
 				
 				if (request.getIsHrp() != null) {


### PR DESCRIPTION
## 📋 Description

JIRA ID:  [AMM-2315](https://support.piramalfoundation.org/jira/browse/AMM-2315)

Please provide a summary of the change and the motivation behind it. Include relevant context and details.
## Summary
- When an agent closes a call with reason "Number busy", "No reply", 
  "Switched off" etc., the record was disappearing from their worklist.
- Root cause: a previous change unallocated ALL disconnected calls 
  unconditionally, including busy/not-answered ones.
- Fix: unallocation is now skipped when `reasonForCallNotAnswered` is 
  a not-answered reason (busy, switched off, no reply, etc.).

## Changes
- `CallClosureImpl.java`: Added condition in disconnected block — 
  unallocation only happens when reason is NOT a busy/not-answered type.
- Removed redundant re-allocation lines from the busy block 
  (no longer needed after fixing root cause).

## Test Plan
- [ ] Close call with "Number busy" → record stays in worklist
- [ ] Close call with "Switched off" → record stays in worklist  
- [ ] Disconnect call (genuine disconnect, no reason) → record goes to unallocated pool
- [ ] Max attempts reached → record removed from worklist as before
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
